### PR TITLE
Fix Jungle not being in warm due to vanilla change

### DIFF
--- a/forestry/api/core/EnumTemperature.java
+++ b/forestry/api/core/EnumTemperature.java
@@ -134,7 +134,7 @@ public enum EnumTemperature {
 		if (rawTemp >= 2.0f) {
 			value = EnumTemperature.HOT;
 		}
-		else if (rawTemp >= 1.2f) {
+		else if (rawTemp >= 0.95f) {
 			value = EnumTemperature.WARM;
 		}
 		else if (rawTemp >= 0.2f) {


### PR DESCRIPTION
Jungle temperature changed to 0.95f in 1.7.x
End result is things like Tropical bees aren't spawning/working any more.
