### PR TITLE
Split IBeekeepingLogic.update() into canWork() and doWork()

### DIFF
--- a/forestry/api/apiculture/IBeekeepingLogic.java
+++ b/forestry/api/apiculture/IBeekeepingLogic.java
@@ -21,7 +21,21 @@ public interface IBeekeepingLogic extends INBTTagable {
 	
 	IEffectData[] getEffectData();
 
-	/* UPDATING */
+	/**
+	 * Checks that the bees can work, setting error conditions on the housing where needed
+	 * @return true if no errors are present and doWork should be called
+	 */
+	boolean canWork();
+
+	/**
+	 * Performs actual work, breeding, production, etc.
+	 */
+	void doWork();
+
+	/**
+	 * @deprecated since Forestry 3.6. use canWork() and doWork() instead
+	 */
+	@Deprecated
 	void update();
 
 }

--- a/forestry/api/apiculture/package-info.java
+++ b/forestry/api/apiculture/package-info.java
@@ -3,6 +3,6 @@
  * 
  * This work (the API) is licensed under the "MIT" License, see LICENSE.txt for details.
  ******************************************************************************/
-@API(apiVersion="3.4.0", owner="ForestryAPI|core", provides="ForestryAPI|apiculture")
+@API(apiVersion="3.5.0", owner="ForestryAPI|core", provides="ForestryAPI|apiculture")
 package forestry.api.apiculture;
 import cpw.mods.fml.common.API;


### PR DESCRIPTION
This is was discussed over IRC with @mezz 

I've split the main update() method into 2 parts

* canWork - checks for all error conditions
 * It also kills dying queens and outputs backlogged items because i don't see a way to cleanly split that away. It also somewhat makes sense to do those things if errors are present.
* doWork - does all the actual work - breeding, production, etc.

This will allow Gendustry (and possibly other mods) that needs to use additional error states a cleaner way to interact with BeekeepingLogic and control when it does/doesn't update.

Flower checks are cached as suggested by @mezz 

I've also deprecated deprecated update() and replaced it in places that used it - not sure if this is desireable, if no - i'll take that out.

This PR is for the API change, once it's merged i'll make another one with the main changes in ForestryMC - you can currently [see it here](https://github.com/ForestryMC/ForestryMC/compare/dev...bdew:beekeepinglogic-refactor?expand=1)